### PR TITLE
Change the opacity of the selected day in the five day forecast.

### DIFF
--- a/src/FiveDayForecastBlock/index.js
+++ b/src/FiveDayForecastBlock/index.js
@@ -3,6 +3,7 @@ import "./style.css";
 import SingleDayForecastBlock from "../SingleDayForecastBlock";
 import DayDetailsBlock from "../DayDetailsBlock";
 import { Router } from "@reach/router";
+import ReactDOM from 'react-dom';
 
 const apiKey = "";
 

--- a/src/SingleDayForecastBlock/index.js
+++ b/src/SingleDayForecastBlock/index.js
@@ -1,12 +1,22 @@
-import React from "react";
+import React, {useState} from "react";
 import "./style.css";
 import { Link } from "@reach/router";
 
 const SingleDayForecastBlock = (props) => {
-	let thisDate = props.date.split(" ").reverse().pop(); // Timestamp not needed here – only date
+	let thisDate = props.date.split(" ").reverse().pop(); // Timestamp not needed here – only show date
 
 	return (
-		<Link to={`/${props.detailsLinkSlug}`}>
+		<Link 
+			to={`/${props.detailsLinkSlug}`} 
+			// Reach Router's method for highlighting an active link...
+			getProps={({ isCurrent }) => {
+      			return {
+       				style: {
+          			opacity: isCurrent ? ".65" : "1"
+        		}
+    		}
+    	}}
+		>
 			<div className="singleDay">
 				<img 
 					className="weatherIcon" 


### PR DESCRIPTION
Using Reach Router's suggested method, change the styling (opacity) of the active (selected) day. The selected day will be darker than the others.